### PR TITLE
More precise cast

### DIFF
--- a/libgloss/libsysbase/close.c
+++ b/libgloss/libsysbase/close.c
@@ -21,7 +21,7 @@ int _DEFUN(_close,(fileDesc),
 #endif
 	int ret = -1;
 	unsigned int dev = 0;
-	unsigned int fd = -1;
+	int fd = -1;
 
 	if(fileDesc!=-1) {
 
@@ -31,7 +31,7 @@ int _DEFUN(_close,(fileDesc),
 			dev = handle->device;
 			handle->refcount--;
 			if (handle->refcount == 0 ) {
-				fd = (unsigned int)handle->fileStruct;
+				fd = (int)handle->fileStruct;
 
 				if(devoptab_list[dev]->close_r)
 					ret = devoptab_list[dev]->close_r(ptr,fd);

--- a/libgloss/libsysbase/fstat.c
+++ b/libgloss/libsysbase/fstat.c
@@ -23,7 +23,7 @@ int _DEFUN (_fstat,(fileDesc, st),
 #endif
 	int ret = -1;
 	unsigned int dev = 0;
-	unsigned int fd = -1;
+	int fd = -1;
 
 	__handle * handle = NULL;
 

--- a/libgloss/libsysbase/lseek.c
+++ b/libgloss/libsysbase/lseek.c
@@ -29,7 +29,7 @@ _off_t _DEFUN (_lseek,(fileDesc, pos, dir),
 //---------------------------------------------------------------------------------
 	_off_t ret = -1;
 	unsigned int dev = 0;
-	unsigned int fd = -1;
+	int fd = -1;
 
 	__handle * handle;
 

--- a/libgloss/libsysbase/read.c
+++ b/libgloss/libsysbase/read.c
@@ -25,7 +25,7 @@ _ssize_t _DEFUN(_read,(fileDesc, ptr, len),
 #endif
 	int ret = -1;
 	unsigned int dev = 0;
-	unsigned int fd = -1;
+	int fd = -1;
 
 	__handle * handle = NULL;
 

--- a/libgloss/libsysbase/write.c
+++ b/libgloss/libsysbase/write.c
@@ -25,7 +25,7 @@ _ssize_t _DEFUN (_write, (fileDesc, ptr, len),
 #endif
 	int ret = -1;
 	unsigned int dev = 0;
-	unsigned int fd = -1;
+	int fd = -1;
 
 	__handle * handle = NULL;
 


### PR DESCRIPTION
Since 2nd parameter type of  `close_r`/`write_r` ... is `int` rather than `unsigned int`.
Types of block scope objects `fd` are changed to `int` from `unsigned` to keep some unnecessary cast/implicit conversion away and make the code clearer.
