### PR TITLE
Fix up devoptab's FindDevice

### DIFF
--- a/libgloss/libsysbase/iosupport.c
+++ b/libgloss/libsysbase/iosupport.c
@@ -62,14 +62,16 @@ const devoptab_t *devoptab_list[STD_MAX] = {
 //---------------------------------------------------------------------------------
 int FindDevice(const char* name) {
 //---------------------------------------------------------------------------------
-	int i = 0, namelen, dev = -1;
+	int i = 0, namelen, dev_namelen, dev = -1;
 
 	if (strchr(name, ':') == NULL) return defaultDevice;
+
+	dev_namelen = strlen(name);
 
 	while(i<STD_MAX) {
 		if(devoptab_list[i]) {
 			namelen = strlen(devoptab_list[i]->name);
-			if(strncmp(devoptab_list[i]->name,name,namelen)==0 ) {
+			if(dev_namelen == namelen && strncmp(devoptab_list[i]->name,name,namelen)==0 ) {
 				if ( name[namelen] == ':' || (isdigit(name[namelen]) && name[namelen+1] ==':' )) {
 					dev = i;
 					break;


### PR DESCRIPTION
If you created two devices with similar prefixes, FindDevice would
only return the first device created since it was only comparing
based on the length of the name registered within devoptab.
This patch enforces that the length of both names must match
prior to comparing.

Example:

sample:/   = device 1
sample2:/  = device 2

FindDevice("sample2:/...")

strncmp("sample", "sample2", 6) == 0

returns device 1