### PR TITLE
fix build_argv compliance

### DIFF
--- a/libgloss/libsysbase/build_argv.c
+++ b/libgloss/libsysbase/build_argv.c
@@ -24,8 +24,9 @@ void build_argv (struct __argv* argstruct ) {
 	} while (data < end);
 
 	*end = '\0';						// Force NULL terminator for last arg
+	argv[argCount] = 0;                                     // Force NULL terminator for argv
 
 	argstruct->argv = argv;
 	argstruct->argc = argCount;
-	argstruct->endARGV = &argv[argCount];
+	argstruct->endARGV = &argv[argCount + 1];
 }


### PR DESCRIPTION
POSIX specifies that argv[argc] is a NULL pointer, and newlib's getopt relies on this. This prevents a crash when the first thing in arena1 is non-NULL (which was happening to me).