### PR TITLE
Add pathconf to sysbase

### DIFF
--- a/libgloss/libsysbase/Makefile.in
+++ b/libgloss/libsysbase/Makefile.in
@@ -66,7 +66,7 @@ OBJCOPY = `if [ -f ${objroot}/../binutils/objcopy ] ; \
 
 # object files needed
 OBJS = abort.o iosupport.o clocks.o environ.o execve.o fork.o fstat.o getpid.o gettod.o \
-	isatty.o kill.o link.o lseek.o lstat.o nanosleep.o open.o read.o sbrk.o sleep.o stat.o usleep.o times.o \
+	isatty.o kill.o link.o lseek.o lstat.o nanosleep.o open.o pathconf.o read.o sbrk.o sleep.o stat.o usleep.o times.o \
 	unlink.o wait.o write.o _exit.o malloc_vars.o \
 	chdir.o mkdir.o rename.o build_argv.o statvfs.o \
 	flock.o handle_manager.o truncate.o ftruncate.o dirent.o fsync.o \

--- a/libgloss/libsysbase/pathconf.c
+++ b/libgloss/libsysbase/pathconf.c
@@ -1,0 +1,53 @@
+#include <errno.h>
+#include <stddef.h>
+#include <unistd.h>
+#include <limits.h>
+
+long pathconf(const char *path, int name) {
+	return fpathconf(-1, name);
+}
+
+long fpathconf(int fd, int name)
+{
+	struct _reent *r = _REENT;
+
+	switch (name) {
+		case _PC_LINK_MAX:
+			return 1;
+		case _PC_MAX_CANON:
+			return MAX_CANON;
+		case _PC_MAX_INPUT:
+			return MAX_INPUT;
+		case _PC_NAME_MAX:
+			return NAME_MAX;
+		case _PC_PATH_MAX:
+			return PATH_MAX;
+		case _PC_PIPE_BUF:
+			return PIPE_BUF;
+		case _PC_CHOWN_RESTRICTED:
+			break; // chown is not implemented
+		case _PC_NO_TRUNC:
+			return 1;
+		case _PC_VDISABLE:
+			break; // termios is not supported
+		case _PC_SYNC_IO:
+			return 1;
+		case _PC_ASYNC_IO:
+		case _PC_PRIO_IO:
+			break;
+		case _PC_FILESIZEBITS:
+			return 64;
+		case _PC_REC_INCR_XFER_SIZE:
+		case _PC_REC_MAX_XFER_SIZE:
+		case _PC_REC_MIN_XFER_SIZE:
+		case _PC_REC_XFER_ALIGN:
+		case _PC_ALLOC_SIZE_MIN:
+		case _PC_SYMLINK_MAX:
+			break;
+		case _PC_2_SYMLINKS:
+			return 0;
+	}
+
+	r->_errno = EINVAL;
+	return -1;
+}


### PR DESCRIPTION
This PR adds `pathconf()` to fix an undefined reference in libstdc++ (for reference, pathconf is a function for querying the values of limits macros at runtime).
This doesn't implement all of the limits, but libstdc++ only needs `pathconf()` for `PATH_MAX` anyway.

If there are any issues, or any suggestions on how best to implement the remaining values, please let me know.