### PR TITLE
Fix return value initialization for open, chmod, lstat, stat, truncate and utime

### DIFF
--- a/libgloss/libsysbase/chmod.c
+++ b/libgloss/libsysbase/chmod.c
@@ -12,10 +12,10 @@ int chmod(const char *path, mode_t mode) {
 
 	/* Get device from path name */
 	dev = FindDevice(path);
+    ret = -1;
 
 	if (dev < 0) {
 		r->_errno = ENODEV;
-		ret = -1;
 	} else {
 		if (devoptab_list[dev]->chmod_r == NULL) {
 			r->_errno=ENOSYS;

--- a/libgloss/libsysbase/lstat.c
+++ b/libgloss/libsysbase/lstat.c
@@ -14,6 +14,7 @@ int lstat (const char *__restrict __path, struct stat *__restrict __buf ) {
 	int dev,ret;
 
 	dev = FindDevice(__path);
+    ret = -1;
 
 	if(dev!=-1) {
 		if (devoptab_list[dev]->lstat_r) {
@@ -23,7 +24,6 @@ int lstat (const char *__restrict __path, struct stat *__restrict __buf ) {
 			r->_errno=ENOSYS;
 		}
 	} else {
-		ret = -1;
 		r->_errno = ENODEV;
 	}
 	return ret;

--- a/libgloss/libsysbase/open.c
+++ b/libgloss/libsysbase/open.c
@@ -22,6 +22,7 @@ int _open( const char *file, int   flags, int   mode) {
 	int dev, fd, ret;
 
 	dev = FindDevice(file);
+    ret = -1;
 
 	fd = -1;
 	if(dev!=-1) {

--- a/libgloss/libsysbase/stat.c
+++ b/libgloss/libsysbase/stat.c
@@ -20,6 +20,7 @@ int _stat( const char  *file, struct stat *st) {
 	int dev,ret;
 
 	dev = FindDevice(file);
+    ret = -1;
 
 	if(dev!=-1) {
 		if (devoptab_list[dev]->stat_r) {
@@ -29,7 +30,6 @@ int _stat( const char  *file, struct stat *st) {
 			r->_errno=ENOSYS;
 		}
 	} else {
-		ret = -1;
 		r->_errno = ENODEV;
 	}
 	return ret;

--- a/libgloss/libsysbase/truncate.c
+++ b/libgloss/libsysbase/truncate.c
@@ -15,6 +15,7 @@ int truncate( const char *file, off_t len) {
 	struct _reent * r = _REENT;
 
 	dev = FindDevice(file);
+    ret = -1;
 
 	if(dev!=-1 && devoptab_list[dev]->open_r && devoptab_list[dev]->close_r &&
 	   devoptab_list[dev]->ftruncate_r)

--- a/libgloss/libsysbase/utime.c
+++ b/libgloss/libsysbase/utime.c
@@ -12,6 +12,7 @@ int utimes(const char *filename, const struct timeval times[2])
         int dev,ret;
 
         dev = FindDevice(filename);
+        ret = -1;
 
         if(dev!=-1) {
                 if (devoptab_list[dev]->utimes_r) {
@@ -21,7 +22,6 @@ int utimes(const char *filename, const struct timeval times[2])
                         r->_errno=ENOSYS;
                 }
         } else {
-                ret = -1;
                 r->_errno = ENODEV;
         }
         return ret;


### PR DESCRIPTION
These functions returns an uninitialized variable instead of -1 if a devoptab does not implement these functions.

This PR only fixes it in the devkitPPC branch, but the same bugs are present in the other branches as well..

Thanks DeltaV for spotting this