### PR TITLE
Remove dummy __getreent

### DIFF
--- a/newlib/libc/reent/getreent.c
+++ b/newlib/libc/reent/getreent.c
@@ -1,3 +1,4 @@
+#if 0
 /* default reentrant pointer when multithread enabled */
 
 #ifdef GETREENT_PROVIDED
@@ -19,4 +20,5 @@ __getreent (void)
   return _impure_ptr;
 }
 
+#endif
 #endif


### PR DESCRIPTION
Calling `__getreent();` through different threads, you will get the same result, but using `getThreadVars()->reent;`  to obtain the reent pointer will result in different values.

By comparing the patch with version 4.2.0, I found that the latest patch retains the default `__getreent()` function, It causes the implementation of the `__syscall_getreent()` from libnx was not called.

This PR should fix https://github.com/devkitPro/newlib/issues/27 and https://github.com/devkitPro/pacman-packages/issues/303